### PR TITLE
Remove tag with special chars from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "m6web/cassandra-bundle",
   "type" : "symfony-bundle",
   "description": "Symfony2 bundle on top of datastax/php-driver",
-  "keywords": ["cassandra", "bundle", "C*"],
+  "keywords": ["cassandra", "bundle"],
   "license" : "MIT",
   "authors": [
     {


### PR DESCRIPTION
Packagist does not allow special characters in this field
