### PR TITLE
Fix call to prepare and prepareAsync

### DIFF
--- a/src/Cassandra/Client.php
+++ b/src/Cassandra/Client.php
@@ -165,7 +165,11 @@ class Client implements Session
      */
     public function prepare($cql, ExecutionOptions $options = null)
     {
-        return $this->send('prepare', [$cql, $options]);
+        if (is_null($options)) {
+            return $this->send('prepare', [$cql]);
+        } else {
+            return $this->send('prepare', [$cql, $options]);
+        }
     }
 
     /**
@@ -180,7 +184,11 @@ class Client implements Session
      */
     public function prepareAsync($cql, ExecutionOptions $options = null)
     {
-        return $this->send('prepareAsync', [$cql, $options]);
+        if (is_null($options)) {
+            return $this->send('prepareAsync', [$cql]);
+        } else {
+            return $this->send('prepareAsync', [$cql, $options]);
+        }
     }
 
     /**


### PR DESCRIPTION
When calling `prepare()` and `prepareAsync()` without a 2nd argument, we had the following fatal :

```
PHP Catchable fatal error:  Argument 2 passed to Cassandra\DefaultSession::prepare() must be an instance of Cassandra\ExecutionOptions, null given
```

This PR fixes this error.
