### PR TITLE
Add persistent session option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ m6web_cassandra:
     dispatch_events: true                 # By default event are triggered on each cassandra command
     clients:
         client_name:
+            persistent_sessions: true     # persistent session connection 
             keyspace: "mykeyspace"        # required keyspace to connect
             load_balancing: "round-robin" # round-robin or dc-aware-round-robin
             dc_options:                   # required if load balancing is set to dc-aware-round-robin

--- a/src/Cassandra/Configurator.php
+++ b/src/Cassandra/Configurator.php
@@ -30,7 +30,8 @@ class Configurator
             ->withPort($config['port_endpoint'])
             ->withTokenAwareRouting($config['token_aware_routing'])
             ->withConnectTimeout($config['timeout']['connect'])
-            ->withRequestTimeout($config['timeout']['request']);
+            ->withRequestTimeout($config['timeout']['request'])
+            ->withPersistentSessions($config['persistent_sessions']);
 
         if (isset($config['ssl']) && $config['ssl'] === true) {
             $ssl = new SSLOptionsBuilder();

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                             ->thenInvalid('"dc-aware-round-robin" load balancing option require a "dc_options" entry in your configuration')
                         ->end()
                         ->children()
+                            ->booleanNode('persistent_sessions')->defaultValue(true)->end()
                             ->scalarNode('keyspace')->isRequired()->cannotBeEmpty()->end()
                             ->scalarNode('load_balancing')
                                 ->defaultValue('round-robin')

--- a/src/Tests/Fixtures/override-config.yml
+++ b/src/Tests/Fixtures/override-config.yml
@@ -2,6 +2,7 @@ m6web_cassandra:
   dispatch_events: false
   clients:
     client_test:
+      persistent_sessions: false
       keyspace: 'test'
       load_balancing: 'dc-aware-round-robin'
       dc_options:

--- a/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
@@ -21,10 +21,12 @@ class M6WebCassandraExtension extends test
             ->boolean($container->has('m6web_cassandra.client.client_test'))
                 ->isTrue()
             ->array($arguments = $container->getDefinition('m6web_cassandra.client.client_test')->getArgument(0))
-                ->hasSize(11)
-                ->hasKeys(['keyspace', 'contact_endpoints', 'load_balancing', 'default_consistency', 'default_pagesize', 'port_endpoint', 'token_aware_routing', 'ssl', 'timeout', 'retries'])
+                ->hasSize(12)
+                ->hasKeys($this->getDefaultConfigKeys())
                 ->notHasKeys(['default_timeout'])
             ->boolean($arguments['dispatch_events'])
+                ->isTrue()
+            ->boolean($arguments['persistent_sessions'])
                 ->isTrue()
             ->string($arguments['keyspace'])
                 ->isEqualTo('test')
@@ -71,9 +73,11 @@ class M6WebCassandraExtension extends test
             ->boolean($container->has('m6web_cassandra.client.client_test'))
                 ->isTrue()
             ->array($arguments = $container->getDefinition('m6web_cassandra.client.client_test')->getArgument(0))
-                ->hasSize(14)
-                ->hasKeys(['keyspace', 'contact_endpoints', 'load_balancing', 'default_consistency', 'default_pagesize', 'port_endpoint', 'token_aware_routing', 'ssl', 'timeout', 'credentials', 'default_timeout', 'dc_options', 'retries'])
+                ->hasSize(15)
+                ->hasKeys($this->getDefaultConfigKeys(['credentials', 'default_timeout', 'dc_options']))
             ->boolean($arguments['dispatch_events'])
+                ->isFalse()
+            ->boolean($arguments['persistent_sessions'])
                 ->isFalse()
             ->string($arguments['keyspace'])
                 ->isEqualTo('test')
@@ -138,8 +142,8 @@ class M6WebCassandraExtension extends test
             ->boolean($container->has('m6web_cassandra.client.client_test'))
                 ->isTrue()
             ->array($arguments = $container->getDefinition('m6web_cassandra.client.client_test')->getArgument(0))
-                ->hasSize(11)
-                ->hasKeys(['keyspace', 'contact_endpoints', 'load_balancing', 'default_consistency', 'default_pagesize', 'port_endpoint', 'token_aware_routing', 'ssl', 'timeout', 'retries'])
+                ->hasSize(12)
+                ->hasKeys($this->getDefaultConfigKeys())
             ->boolean($arguments['dispatch_events'])
                 ->isTrue()
             ->string($arguments['keyspace'])
@@ -155,8 +159,8 @@ class M6WebCassandraExtension extends test
             ->boolean($container->has('m6web_cassandra.client.client_test2'))
                 ->isTrue()
             ->array($arguments2 = $container->getDefinition('m6web_cassandra.client.client_test2')->getArgument(0))
-                ->hasSize(13)
-                ->hasKeys(['keyspace', 'contact_endpoints', 'load_balancing', 'default_consistency', 'default_pagesize', 'port_endpoint', 'token_aware_routing', 'ssl', 'timeout', 'credentials', 'dc_options'])
+                ->hasSize(14)
+                ->hasKeys($this->getDefaultConfigKeys(['credentials', 'dc_options']))
             ->boolean($arguments['dispatch_events'])
                 ->isTrue()
             ->string($arguments2['keyspace'])
@@ -268,5 +272,25 @@ class M6WebCassandraExtension extends test
         $loader->load($fixtureName.'.yml');
 
         return $container;
+    }
+
+    protected function getDefaultConfigKeys(array $keySup = [])
+    {
+            return array_merge(
+                [
+                'persistent_sessions',
+                'keyspace',
+                'contact_endpoints',
+                'load_balancing',
+                'default_consistency',
+                'default_pagesize',
+                'port_endpoint',
+                'token_aware_routing',
+                'ssl',
+                'timeout',
+                'retries'
+                ],
+                $keySup
+            );
     }
 }


### PR DESCRIPTION
Taking car of new option in datastax component available since beta allowing to toggle the persistent connexion to cassandra.
