### PR TITLE
Update composer.json and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Require the bundle in your composer.json file :
 ```json
 {
     "require": {
-        "m6web/cassandra-bundle": "1.0.0-beta",
+        "m6web/cassandra-bundle": "~1.0.0-beta",
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": ">=5.5",
-    "datastax/php-driver": "dev-master"
+    "ext-cassandra": "*"
   },
   "require-dev": {
     "atoum/atoum": "~2.0",
@@ -22,7 +22,8 @@
     "symfony/dependency-injection": "~2.3",
     "symfony/event-dispatcher": "~2.3",
     "symfony/config" : "~2.3",
-    "symfony/yaml" : "~2.3"
+    "symfony/yaml" : "~2.3",
+    "datastax/php-driver": "dev-master"
   },
   "autoload": {
     "psr-4": {"M6Web\\Bundle\\CassandraBundle\\": "src/"}


### PR DESCRIPTION
Now, require section need cassandra extension.
- datastax/php-driver required only in dev for stubs
- add a require for cassandra extension

Datastax php classes are in the extension since beta, so we don't need the php-driver project in the require section. 
