### PR TITLE
added : performNoDeepMerging for contact_endpoints config statements

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -59,7 +59,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->integerNode('default_pagesize')->deFaultValue(10000)->end()
-                            ->arrayNode('contact_endpoints')->isRequired()->requiresAtLeastOneElement()
+                            ->arrayNode('contact_endpoints')->isRequired()->requiresAtLeastOneElement()->performNoDeepMerging()
                                 ->prototype('scalar')->end()
                             ->end()
                             ->integerNode('port_endpoint')->defaultValue(9042)->end()

--- a/src/Tests/Fixtures/override-config-with-import.yml
+++ b/src/Tests/Fixtures/override-config-with-import.yml
@@ -1,0 +1,10 @@
+imports:
+    - { resource: default-config.yml }
+
+m6web_cassandra:
+  clients:
+    client_test:
+      contact_endpoints:
+        - '127.0.0.4'
+        - '127.0.0.5'
+        - '127.0.0.6'

--- a/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
@@ -133,6 +133,26 @@ class M6WebCassandraExtension extends test
         ;
     }
 
+    public function testOverrideDefaultEndPointsConfig()
+    {
+        $container = $this->getContainerForConfiguation('override-config-with-import');
+        $container->compile();
+
+        $this
+            ->boolean($container->has('m6web_cassandra.client.client_test'))
+                ->isTrue()
+            ->array($arguments = $container->getDefinition('m6web_cassandra.client.client_test')->getArgument(0))
+            ->array($endpoints = $arguments['contact_endpoints'])
+                ->hasSize(3)
+                ->string($endpoints[0])
+                    ->isEqualTo('127.0.0.4')
+                ->string($endpoints[1])
+                    ->isEqualTo('127.0.0.5')
+                ->string($endpoints[2])
+                    ->isEqualTo('127.0.0.6')
+        ;
+    }
+
     public function testMulticlientsConfig()
     {
         $container = $this->getContainerForConfiguation('multiclients');


### PR DESCRIPTION
different "contact_endpoints" configurations (in the bundle m6web_cassandra.clients section) now override old ones, instead of being appended.
