### PR TITLE
Modifier la valeur à saisir pour désactiver la pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ m6web_cassandra:
                 host_per_remote_dc: 3
                 remote_dc_for_local_consistency: false
             default_consistency: "one"    # 'one', 'any', 'two', 'three', 'quorum', 'all', 'local_quorum', 'each_quorum', 'serial', 'local_serial', 'local_one'
-            default_pagesize: 10000       # -1 to disable pagination
+            default_pagesize: 10000       # ~ to disable pagination
             contact_endpoints:            # required list of ip to contact
                 - 127.0.0.1
             port_endpoint: 9042           # cassandra port

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -58,7 +58,15 @@ class Configuration implements ConfigurationInterface
                                     ->thenInvalid('Invalid consistency value "%s"')
                                 ->end()
                             ->end()
-                            ->integerNode('default_pagesize')->deFaultValue(10000)->end()
+                            ->scalarNode('default_pagesize')
+                                ->defaultValue(10000)
+                                ->validate()
+                                    ->ifTrue(function ($v) {
+                                        return !is_null($v) && (!is_int($v) || $v <= 0);
+                                    })
+                                    ->thenInvalid('Expected positive integer or null value')
+                                ->end()
+                            ->end()
                             ->arrayNode('contact_endpoints')->isRequired()->requiresAtLeastOneElement()->performNoDeepMerging()
                                 ->prototype('scalar')->end()
                             ->end()

--- a/src/Tests/Fixtures/override-config-with-import.yml
+++ b/src/Tests/Fixtures/override-config-with-import.yml
@@ -8,3 +8,4 @@ m6web_cassandra:
         - '127.0.0.4'
         - '127.0.0.5'
         - '127.0.0.6'
+      default_pagesize: ~

--- a/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
+++ b/src/Tests/Units/DependencyInjection/M6WebCassandraExtension.php
@@ -150,6 +150,8 @@ class M6WebCassandraExtension extends test
                     ->isEqualTo('127.0.0.5')
                 ->string($endpoints[2])
                     ->isEqualTo('127.0.0.6')
+            ->variable($arguments['default_pagesize'])
+                ->isNull()
         ;
     }
 


### PR DESCRIPTION
Pour désactiver la pagination, le driver PHP Cassandra attend la valeur `null`. Hors ici le bundle attend comme valeur `-1`.

> default_pagesize: 10000       # -1 to disable pagination

Le driver cassandra génère l'erreur suivante dans ce cas :
`pageSize must be a positive integer or null, -1 given`

Modification de la vérification de la configuration
Mise à jour de la documentation
Mise à jour des tests unitaires pour tester la valeur null passée dans la configuration
