### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__.'/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.5
   - 7.0
+  - 7.1
 
 env:
   - SYMFONY_VERSION="~2.3.0"
@@ -20,7 +21,7 @@ before_install:
   - sudo apt-add-repository ppa:linuxjedi/ppa -y
   - sudo apt-get update
   - sudo apt-get install -y libuv-dev libssl-dev
-  - cd /tmp && git clone https://github.com/datastax/php-driver.git && cd php-driver && git submodule update --init
+  - cd /tmp && git clone https://github.com/datastax/php-driver.git && cd php-driver && git checkout v1.2.2 && git submodule update --init
   - cd ext && ./install.sh && cd "$TRAVIS_BUILD_DIR"
   - echo "extension=cassandra.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
 

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
   ],
   "require": {
     "php": ">=5.5",
-    "ext-cassandra": "*"
+    "ext-cassandra": "<1.3.0"
   },
   "require-dev": {
-    "atoum/atoum": "~2.0",
+    "atoum/atoum": "^2.8||^3.0",
     "m6web/coke": "~1.2",
     "m6web/symfony2-coding-standard": "~2.0",
     "symfony/dependency-injection": "~2.3",


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.