### PR TITLE
Fix deprecated ExecutionOptions with cassandra-driver 1.3

### DIFF
--- a/src/Cassandra/Client.php
+++ b/src/Cassandra/Client.php
@@ -1,7 +1,6 @@
 <?php
 namespace M6Web\Bundle\CassandraBundle\Cassandra;
 
-use Cassandra\ExecutionOptions;
 use Cassandra\Future;
 use Cassandra\PreparedStatement;
 use Cassandra\Session;
@@ -129,8 +128,8 @@ class Client implements Session
     /**
      * Executes a given statement and returns a result
      *
-     * @param Statement        $statement statement to be executed
-     * @param ExecutionOptions $options   execution options
+     * @param Statement $statement statement to be executed
+     * @param array     $options   execution options
      *
      * @throws \Cassandra\Exception
      *
@@ -144,11 +143,11 @@ class Client implements Session
     /**
      * Executes a given statement and returns a future result
      *
-     * Note that this method ignores ExecutionOptions::$timeout option, you can
+     * Note that this method ignores $options['timeout'] option, you can
      * provide one to Future::get() instead.
      *
-     * @param Statement        $statement statement to be executed
-     * @param ExecutionOptions $options   execution options
+     * @param Statement $statement statement to be executed
+     * @param array     $options   execution options
      *
      * @return \Cassandra\Future     future result
      */
@@ -160,11 +159,11 @@ class Client implements Session
     /**
      * Creates a prepared statement from a given CQL string
      *
-     * Note that this method only uses the ExecutionOptions::$timeout option,
+     * Note that this method only uses the $options['timeout'] option,
      * all other options will be ignored.
      *
-     * @param string           $cql     CQL statement string
-     * @param ExecutionOptions $options execution options
+     * @param string $cql     CQL statement string
+     * @param array  $options execution options
      *
      * @throws \Cassandra\Exception
      *
@@ -180,8 +179,8 @@ class Client implements Session
      *
      * Note that all options passed to this method will be ignored.
      *
-     * @param string           $cql     CQL string to be prepared
-     * @param ExecutionOptions $options preparation options
+     * @param string $cql     CQL string to be prepared
+     * @param array  $options preparation options
      *
      * @return \Cassandra\Future  statement
      */

--- a/src/DataCollector/CassandraDataCollector.php
+++ b/src/DataCollector/CassandraDataCollector.php
@@ -68,11 +68,11 @@ class CassandraDataCollector extends DataCollector
     public function onCassandraCommand(CassandraEvent $event)
     {
         $data = [
-            'keyspace'         => $event->getKeyspace(),
-            'command'          => $event->getCommand(),
-            'argument'         => $this->getArguments($event),
-            'executionOptions' => $this->getExecutionOptions($event),
-            'executionTime'    => $event->getExecutionTime()
+            'keyspace'      => $event->getKeyspace(),
+            'command'       => $event->getCommand(),
+            'argument'      => $this->getArguments($event),
+            'options'       => $this->getOptions($event),
+            'executionTime' => $event->getExecutionTime()
         ];
 
         $this->data['cassandra']->enqueue($data);
@@ -139,28 +139,16 @@ class CassandraDataCollector extends DataCollector
      *
      * @return array
      */
-    protected function getExecutionOptions(CassandraEvent $event)
+    protected function getOptions(CassandraEvent $event)
     {
-        $arguments = $event->getArguments();
-
-        if (empty($arguments[1])) {
-            return [
-                'consistency'       => '',
-                'serialConsistency' => '',
-                'pageSize'          => '',
-                'timeout'           => '',
-                'arguments'         => ''
-            ];
-        }
-
-        $options = $arguments[1];
+        $options = $event->getArguments()[1];
 
         return [
-            'consistency'       => self::getConsistency($options->consistency),
-            'serialConsistency' => self::getConsistency($options->serialConsistency),
-            'pageSize'          => $options->pageSize,
-            'timeout'           => $options->timeout,
-            'arguments'         => var_export($options->arguments, true)
+            'consistency'       => self::getConsistency($options['consistency'] ?? ''),
+            'serialConsistency' => self::getConsistency($options['serialConsistency'] ?? ''),
+            'pageSize'          => $options['pageSize'] ?? '',
+            'timeout'           => $options['timeout'] ?? '',
+            'arguments'         => var_export($options['arguments'] ?? '', true)
         ];
 
     }

--- a/src/Resources/views/Collector/cassandra.html.twig
+++ b/src/Resources/views/Collector/cassandra.html.twig
@@ -55,16 +55,16 @@
                     {% if command.argument == 'Statement' %}
                         <strong>{{ command.argument }}</strong> with arguments :
                         <br />
-                        <pre>{{ command.executionOptions.arguments }}</pre>
+                        <pre>{{ command.options['arguments'] }}</pre>
                     {% else %}
                         {{ command.argument }}
                     {% endif %}
                 </td>
                 <td>{{ command.executionTime|number_format(6) }}</td>
-                <td>{{ command.executionOptions.consistency }}</td>
-                <td>{{ command.executionOptions.serialConsistency }}</td>
-                <td>{{ command.executionOptions.pageSize }}</td>
-                <td>{{ command.executionOptions.timeout }}</td>
+                <td>{{ command.options['consistency'] }}</td>
+                <td>{{ command.options['serialConsistency'] }}</td>
+                <td>{{ command.options['pageSize'] }}</td>
+                <td>{{ command.options['timeout'] }}</td>
             </tr>
         {% endfor %}
         </tboby>


### PR DESCRIPTION
Remove deprecated executionOptions to be compatible with cassandra-driver v1.3.0