### PR TITLE
Add CassandraDataCollector::reset() method required for Symfony 4

### DIFF
--- a/src/DataCollector/CassandraDataCollector.php
+++ b/src/DataCollector/CassandraDataCollector.php
@@ -35,7 +35,17 @@ class CassandraDataCollector extends DataCollector
      */
     public function __construct()
     {
-        $this->data['cassandra'] = new \SplQueue();
+        $this->reset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [
+            'cassandra' => new \SplQueue(),
+        ];
     }
 
     /**


### PR DESCRIPTION
## Why?
Fixes https://github.com/M6Web/CassandraBundle/issues/34

## How?
Took example from here => https://github.com/M6Web/AmqpBundle/blob/master/src/AmqpBundle/Amqp/DataCollector.php#L96-L99