### PR TITLE
Error on CassandraDataCollector template naming in Symfony4

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -2,5 +2,5 @@ services:
     m6web.data_collector.cassandra:
         class: M6Web\Bundle\CassandraBundle\DataCollector\CassandraDataCollector
         tags:
-            - { name: data_collector, template: 'M6WebCassandraBundle:Collector:cassandra', id: 'cassandra' }
+            - { name: data_collector, template: '@M6WebCassandra/Collector/cassandra.html.twig', id: 'cassandra' }
             - { name: kernel.event_listener, event: m6web.cassandra, method: onCassandraCommand }

--- a/src/Resources/views/Collector/cassandra.html.twig
+++ b/src/Resources/views/Collector/cassandra.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,7 +7,7 @@
     {% set text %}
     {{ collector.commands | length }} commands (avg : {{ collector.avgexecutiontime|number_format(4) }} - total : {{ collector.totalexecutiontime|number_format(4) }})
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': true } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': true } %}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
After a fresh install of CassandraBundle in Symfony4, there is an error in web debug toolbar loading :
**The profiler template "M6WebCassandraBundle:Collector:cassandra.html.twig" for data collector "cassandra" does not exist.**
In Symfony4 template naming have changed.