### PR TITLE
Fix a couple of SF4 deprecations

### DIFF
--- a/.coke
+++ b/.coke
@@ -6,3 +6,4 @@ standard=vendor/m6web/symfony2-coding-standard/Symfony2
 src/
 
 !Tests
+!src/EventDispatcher/CassandraEvent.php

--- a/src/Cassandra/Client.php
+++ b/src/Cassandra/Client.php
@@ -17,6 +17,8 @@ use M6Web\Bundle\CassandraBundle\EventDispatcher\CassandraEvent;
  */
 class Client implements Session
 {
+    use EventDispatcherTrait;
+
     /**
      * @var array
      */
@@ -285,7 +287,7 @@ class Client implements Session
         }
 
         $event->setExecutionStop();
-        $this->eventDispatcher->dispatch(CassandraEvent::EVENT_NAME, $event);
+        $this->dispatchEvent($event, CassandraEvent::EVENT_NAME);
 
         return $response;
     }

--- a/src/Cassandra/EventDispatcherTrait.php
+++ b/src/Cassandra/EventDispatcherTrait.php
@@ -1,0 +1,57 @@
+<?php
+namespace M6Web\Bundle\CassandraBundle\Cassandra;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use M6Web\Bundle\CassandraBundle\EventDispatcher\CassandraEvent;
+
+/**
+ * Trait EventDispatcherTrait
+ *
+ * Dispatch Cassandra events correctly for all versions of Symfony
+ * and work around the breaking change in Symfony 4.3 that reversed
+ * the order of arguments of the dispatch() method in interface
+ * EventDispatcherInterface.
+ */
+trait EventDispatcherTrait
+{
+    /**
+     * @var boolean
+     */
+    protected $eventDispatcherTakesEventNameAsFirstArgument;
+
+    /**
+     * Initialize the trait
+     *
+     * Identify whether the event dispatcher takes the event name as
+     * first argument in the dispatch() method.
+     */
+    private function initializeEventDispatcherTrait()
+    {
+        $rfl = new \ReflectionMethod(EventDispatcherInterface::class, 'dispatch');
+        $params = $rfl->getParameters();
+        $this->eventDispatcherTakesEventNameAsFirstArgument = $params[0]->getName() === "eventName";
+    }
+
+    /**
+     * Dispatch the event in the appropriate way by the event dispatcher
+     *
+     * In a breaking change in Symfony 4.3, the order of arguments of the dispatch()
+     * method have changed, this method does the right thing depending on the
+     * version of the Symfony EventDispatcher component used.
+     *
+     * @param CassandraEvent $event The event to dispatch
+     * @param string $eventName The name of the event to dispatch
+     */
+    protected function dispatchEvent(CassandraEvent $event, string $eventName)
+    {
+        if (!isset($this->eventDispatcherTakesEventNameAsFirstArgument)) {
+            $this->initializeEventDispatcherTrait();
+        }
+
+        if ($this->eventDispatcherTakesEventNameAsFirstArgument) {
+            $this->eventDispatcher->dispatch($eventName, $event);
+        } else {
+            $this->eventDispatcher->dispatch($event, $eventName);
+        }
+    }
+}

--- a/src/Cassandra/FutureResponse.php
+++ b/src/Cassandra/FutureResponse.php
@@ -12,6 +12,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class FutureResponse implements Future
 {
+    use EventDispatcherTrait;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -54,7 +56,7 @@ class FutureResponse implements Future
         $return = $this->future->get($timeout);
 
         $this->event->setExecutionStop();
-        $this->eventDispatcher->dispatch(CassandraEvent::EVENT_NAME, $this->event);
+        $this->dispatchEvent($this->event, CassandraEvent::EVENT_NAME);
 
         return $return;
     }

--- a/src/EventDispatcher/CassandraEvent.php
+++ b/src/EventDispatcher/CassandraEvent.php
@@ -1,156 +1,322 @@
 <?php
 namespace M6Web\Bundle\CassandraBundle\EventDispatcher;
 
+use Symfony\Contracts\EventDispatcher\ContractsEvent;
 use Symfony\Component\EventDispatcher\Event;
 
-/**
- * Class CassandraEvent
+/*
+ * Since Symfony 4.3, Event should derive from the contract class
+ * and not the class from the EventDispatcher component. In order to
+ * maintain compatibility with Symfony < 4.3, it's necessary to check
+ * for the existence of the Contracts class.
+ *
+ * Apparently, there are no more clever ways than duplicating the class
+ * definition for both cases, see
+ * https://github.com/symfony/symfony/blob/4.4/src/Symfony/Contracts/EventDispatcher/Event.php
+ * for another example where it's done.
  */
-class CassandraEvent extends Event
-{
-    const EVENT_NAME = 'm6web.cassandra';
-
+if (class_exists(ContractsEvent::class)) {
     /**
-     * Cassandra keyspace where event was dispatched
-     *
-     * @var string
+     * Class CassandraEvent
      */
-    protected $keyspace;
-
-    /**
-     * Cassandra's session command invoked
-     *
-     * @var string
-     */
-    protected $command;
-
-    /**
-     * Command arguments
-     *
-     * @var array
-     */
-    protected $arguments;
-
-    /**
-     * Command execution time
-     *
-     * @var float
-     */
-    protected $executionStart;
-
-    /**
-     * @var float
-     */
-    protected $executionTime;
-
-    /**
-     * @param string $keyspace
-     *
-     * @return CassandraEvent
-     */
-    public function setKeyspace($keyspace)
+    class CassandraEvent extends ContractsEvent
     {
-        $this->keyspace = $keyspace;
+        const EVENT_NAME = 'm6web.cassandra';
 
-        return $this;
+        /**
+         * Cassandra keyspace where event was dispatched
+         *
+         * @var string
+         */
+        protected $keyspace;
+
+        /**
+         * Cassandra's session command invoked
+         *
+         * @var string
+         */
+        protected $command;
+
+        /**
+         * Command arguments
+         *
+         * @var array
+         */
+        protected $arguments;
+
+        /**
+         * Command execution time
+         *
+         * @var float
+         */
+        protected $executionStart;
+
+        /**
+         * @var float
+         */
+        protected $executionTime;
+
+        /**
+         * @param string $keyspace
+         *
+         * @return CassandraEvent
+         */
+        public function setKeyspace($keyspace)
+        {
+            $this->keyspace = $keyspace;
+
+            return $this;
+        }
+
+        /**
+         * @return string
+         */
+        public function getKeyspace()
+        {
+            return $this->keyspace;
+        }
+
+        /**
+         * @return array
+         */
+        public function getArguments()
+        {
+            return $this->arguments;
+        }
+
+        /**
+         * @param array $arguments
+         *
+         * @return CassandraEvent
+         */
+        public function setArguments(array $arguments)
+        {
+            $this->arguments = $arguments;
+
+            return $this;
+        }
+
+        /**
+         * @return string
+         */
+        public function getCommand()
+        {
+            return $this->command;
+        }
+
+        /**
+         * @param string $command
+         *
+         * @return CassandraEvent
+         */
+        public function setCommand($command)
+        {
+            $this->command = $command;
+
+            return $this;
+        }
+
+        /**
+         * @return float
+         */
+        public function getExecutionStart()
+        {
+            return $this->executionStart;
+        }
+
+        /**
+         * Set execution start of a cassandra request
+         *
+         * @return CassandraEvent
+         */
+        public function setExecutionStart()
+        {
+            $this->executionStart = microtime(true);
+
+            return $this;
+        }
+
+        /**
+         * Stop the execution of cassandra request
+         * and set the request execution time
+         *
+         * @return CassandraEvent
+         */
+        public function setExecutionStop()
+        {
+            $this->executionTime = microtime(true) - $this->executionStart;
+
+            return $this;
+        }
+
+        /**
+         * @return float
+         */
+        public function getExecutionTime()
+        {
+            return $this->executionTime;
+        }
+
+        /**
+         * Return execution time in milliseconds
+         *
+         * @return float
+         */
+        public function getTiming()
+        {
+            return $this->getExecutionTime() * 1000;
+        }
     }
-
+} else {
     /**
-     * @return string
+     * Class CassandraEvent
      */
-    public function getKeyspace()
+    class CassandraEvent extends Event
     {
-        return $this->keyspace;
-    }
+        const EVENT_NAME = 'm6web.cassandra';
 
-    /**
-     * @return array
-     */
-    public function getArguments()
-    {
-        return $this->arguments;
-    }
+        /**
+         * Cassandra keyspace where event was dispatched
+         *
+         * @var string
+         */
+        protected $keyspace;
 
-    /**
-     * @param array $arguments
-     *
-     * @return CassandraEvent
-     */
-    public function setArguments(array $arguments)
-    {
-        $this->arguments = $arguments;
+        /**
+         * Cassandra's session command invoked
+         *
+         * @var string
+         */
+        protected $command;
 
-        return $this;
-    }
+        /**
+         * Command arguments
+         *
+         * @var array
+         */
+        protected $arguments;
 
-    /**
-     * @return string
-     */
-    public function getCommand()
-    {
-        return $this->command;
-    }
+        /**
+         * Command execution time
+         *
+         * @var float
+         */
+        protected $executionStart;
 
-    /**
-     * @param string $command
-     *
-     * @return CassandraEvent
-     */
-    public function setCommand($command)
-    {
-        $this->command = $command;
+        /**
+         * @var float
+         */
+        protected $executionTime;
 
-        return $this;
-    }
+        /**
+         * @param string $keyspace
+         *
+         * @return CassandraEvent
+         */
+        public function setKeyspace($keyspace)
+        {
+            $this->keyspace = $keyspace;
 
-    /**
-     * @return float
-     */
-    public function getExecutionStart()
-    {
-        return $this->executionStart;
-    }
+            return $this;
+        }
 
-    /**
-     * Set execution start of a cassandra request
-     *
-     * @return CassandraEvent
-     */
-    public function setExecutionStart()
-    {
-        $this->executionStart = microtime(true);
+        /**
+         * @return string
+         */
+        public function getKeyspace()
+        {
+            return $this->keyspace;
+        }
 
-        return $this;
-    }
+        /**
+         * @return array
+         */
+        public function getArguments()
+        {
+            return $this->arguments;
+        }
 
-    /**
-     * Stop the execution of cassandra request
-     * and set the request execution time
-     *
-     * @return CassandraEvent
-     */
-    public function setExecutionStop()
-    {
-        $this->executionTime = microtime(true) - $this->executionStart;
+        /**
+         * @param array $arguments
+         *
+         * @return CassandraEvent
+         */
+        public function setArguments(array $arguments)
+        {
+            $this->arguments = $arguments;
 
-        return $this;
-    }
+            return $this;
+        }
 
-    /**
-     * @return float
-     */
-    public function getExecutionTime()
-    {
-        return $this->executionTime;
-    }
+        /**
+         * @return string
+         */
+        public function getCommand()
+        {
+            return $this->command;
+        }
 
-    /**
-     * Return execution time in milliseconds
-     *
-     * @return float
-     */
-    public function getTiming()
-    {
-        return $this->getExecutionTime() * 1000;
+        /**
+         * @param string $command
+         *
+         * @return CassandraEvent
+         */
+        public function setCommand($command)
+        {
+            $this->command = $command;
+
+            return $this;
+        }
+
+        /**
+         * @return float
+         */
+        public function getExecutionStart()
+        {
+            return $this->executionStart;
+        }
+
+        /**
+         * Set execution start of a cassandra request
+         *
+         * @return CassandraEvent
+         */
+        public function setExecutionStart()
+        {
+            $this->executionStart = microtime(true);
+
+            return $this;
+        }
+
+        /**
+         * Stop the execution of cassandra request
+         * and set the request execution time
+         *
+         * @return CassandraEvent
+         */
+        public function setExecutionStop()
+        {
+            $this->executionTime = microtime(true) - $this->executionStart;
+
+            return $this;
+        }
+
+        /**
+         * @return float
+         */
+        public function getExecutionTime()
+        {
+            return $this->executionTime;
+        }
+
+        /**
+         * Return execution time in milliseconds
+         *
+         * @return float
+         */
+        public function getTiming()
+        {
+            return $this->getExecutionTime() * 1000;
+        }
     }
 }


### PR DESCRIPTION
There are two deprecations left in the bundle that trigger under Symfony 4.4:

"Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead."

Events should depend on the abstraction Symfony\Contracts\EventDispatcher\Event, not the concretion Symfony\Component\EventDispatcher\Event.